### PR TITLE
Fix `ssa_greedy_optimize` function for inputs with duplicated tensors

### DIFF
--- a/src/Solvers/Greedy.jl
+++ b/src/Solvers/Greedy.jl
@@ -53,7 +53,7 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     ssa_path = Vector{NTuple{2,Int}}()
 
     # step 1: deduplicate shapes by eagerly computing Hadamard products (i.e. element-wise multiplication)
-    remaining = Dict{Int,Set{Symbol}}(i => inds for (i, inds) ∈ enumerate(inputs)) # key -> ssa_id
+    remaining = Dict{Int,Set{Symbol}}(i => inds for (i, inds) ∈ enumerate(inputs))
     ssa_ids = length(inputs) + 1
 
     for input ∈ nonunique(inputs)

--- a/src/Solvers/Greedy.jl
+++ b/src/Solvers/Greedy.jl
@@ -77,7 +77,6 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     # if it appears in 3+, then it cannot be contracted (but indirect Hadamard products can)
     target_inds_histogram = histogram(Iterators.filter(∈(target_inds), Iterators.flatten(values(remaining))))
     high_ocurrent_inds = keys(filter(>(2) ∘ last, target_inds_histogram))
-    # target_inds_histogram[:c] = 3
     # generate candidate pairwise contractions
     queue = BinaryMinHeap{HeapNode{Int,NTuple{3,Set{Symbol}}}}()
 

--- a/src/Solvers/Greedy.jl
+++ b/src/Solvers/Greedy.jl
@@ -53,31 +53,31 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     ssa_path = Vector{NTuple{2,Int}}()
 
     # step 1: deduplicate shapes by eagerly computing Hadamard products (i.e. element-wise multiplication)
-    remaining = Dict{Int,Set{Symbol}}(i => inds for (i, inds) ∈ enumerate(inputs))
+    remaining = Dict{Int,Set{Symbol}}(i => inds for (i, inds) ∈ enumerate(inputs)) # key -> ssa_id
     ssa_ids = length(inputs) + 1
 
     for input ∈ nonunique(inputs)
         reduce(Iterators.filter(isequal(input) ∘ last, enumerate(inputs))) do (i, _), (j, _)
             push!(ssa_path, (i, j))
-
+            delete!(remaining, i)
+            delete!(remaining, j)
             new_ssa_id = ssa_ids
             ssa_ids += 1
             remaining[new_ssa_id] = input
+
             return (new_ssa_id, nothing)
         end
     end
-
     # step 2: greedily compute contractions to minimize `cost_fn` (i.e. maximize `removed_size`)
 
     # list of indices to contract
     target_inds = setdiff(unique(Iterators.flatten(values(remaining))), output)
-
     # histogram of ocurrences of target indices
     # i.e. a index can only be contracted if it only appears in 2 tensors
     # if it appears in 3+, then it cannot be contracted (but indirect Hadamard products can)
     target_inds_histogram = histogram(Iterators.filter(∈(target_inds), Iterators.flatten(values(remaining))))
     high_ocurrent_inds = keys(filter(>(2) ∘ last, target_inds_histogram))
-
+    # target_inds_histogram[:c] = 3
     # generate candidate pairwise contractions
     queue = BinaryMinHeap{HeapNode{Int,NTuple{3,Set{Symbol}}}}()
 
@@ -98,7 +98,7 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     while !isempty(queue)
         # select candidate
         winner = choose_fn(queue, remaining)
-        if winner == nothing
+        if winner === nothing
             continue
         end
         (a, b, c) = meta(winner)


### PR DESCRIPTION
Following the issue #9 (although not fully fixed for all situations). 

### Summary
Now the `ssa_greedy_optimize` does work for inputs with duplicated tensors.

### Example
```julia
julia> using OptimizedEinsum
julia> output = Symbol[]
julia> inputs = [[:a, :b, :c], [:b, :a, :c], [:a, :b]]
julia> size_dict = Dict(:a => 4, :b => 6, :c => 5)
julia> path = contractpath(Greedy, inputs, output, size_dict)
ContractionPath([(1, 2), (3, 4)], [[:a, :b, :c], [:b, :a, :c], [:a, :b]], Symbol[], Dict(:a => 4, :b => 6, :c => 5))
```