### PR TITLE
Fix initialization of the optimizers

### DIFF
--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -4,7 +4,7 @@ abstract type Solver end
 
 function contractpath end
 
-contractpath(T::Type{<:Solver}, inputs, output, size_dict, kwargs...) = contractpath(T(kwargs...), inputs, output, size_dict)
+contractpath(T::Type{<:Solver}, inputs, output, size_dict; kwargs...) = contractpath(T(; kwargs...), inputs, output, size_dict)
 
 include("Optimal.jl")
 include("Greedy.jl")


### PR DESCRIPTION
### Summary:
Now we successfully can add `kwargs` to the optimizers when calling the function `contractpath`.

### Example:
```julia
julia> using OptimizedEinsum
[ Info: Precompiling OptimizedEinsum [c9cfed12-e746-47c4-860d-affc68c43467]
julia> output, inputs, size_dict = rand_equation(4,2)
(Symbol[], [[:b], [:d, :b, :c, :a], [:a, :d], [:c]], Dict(:a => 4, :b => 2, :d => 5, :c => 9))
julia> f(x,y) = x+y
f (generic function with 1 method)
julia> path = contractpath(Greedy, inputs, output, size_dict; cost_fn=OptimizedEinsum.removedsize)
ContractionPath([(2, 3), (5, 4), (6, 1)], [[:b], [:d, :b, :c, :a], [:a, :d], [:c]], Symbol[], Dict(:a => 4, :b => 2, :d => 5, :c => 9))
```