### PR TITLE
Refactor type of `flops`, `size` outputs from `ssa_path_cost` to `BigInt`

### DIFF
--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -1,7 +1,7 @@
 using Base.Iterators: flatten
 
-flops(a, b, size) = prod(ind -> size[ind], a ∪ b, init=1)
-flops(a, b, size, keep) = prod(ind -> size[ind], flatten((a ∪ b, ∩(keep, a, b))), init=1)
+flops(a, b, size) = prod(ind -> size[ind], a ∪ b, init=BigInt(1))
+flops(a, b, size, keep) = prod(ind -> size[ind], flatten((a ∪ b, ∩(keep, a, b))), init=BigInt(1))
 
 rank(a, b, size, keep) = length(symdiff(a, b) ∪ ∩(keep, a, b))
 

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -1,7 +1,7 @@
 using Base.Iterators: flatten
 
-flops(a, b, size) = prod(ind -> size[ind], a ∪ b, init=BigInt(1))
-flops(a, b, size, keep) = prod(ind -> size[ind], flatten((a ∪ b, ∩(keep, a, b))), init=BigInt(1))
+flops(a, b, size) = prod(ind -> size[ind], a ∪ b, init=one(BigInt))
+flops(a, b, size, keep) = prod(ind -> size[ind], flatten((a ∪ b, ∩(keep, a, b))), init=one(BigInt))
 
 rank(a, b, size, keep) = length(symdiff(a, b) ∪ ∩(keep, a, b))
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -165,8 +165,8 @@ Compute the flops and max size of an ssa path.
 """
 function ssa_path_cost(ssa_path, inputs, output, size)
     inputs = copy(inputs)
-    cost = Int128(0)
-    max_size = Int(1)
+    cost = Int(0)
+    max_size = BigInt(1)
 
     for (i, j) in ssa_path
         a, b = inputs[i], inputs[j]

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -165,8 +165,8 @@ Compute the flops and max size of an ssa path.
 """
 function ssa_path_cost(ssa_path, inputs, output, size)
     inputs = copy(inputs)
-    cost = Int(0)
-    max_size = BigInt(1)
+    cost = zero(BigInt)
+    max_size = one(BigInt)
 
     for (i, j) in ssa_path
         a, b = inputs[i], inputs[j]


### PR DESCRIPTION
### Summary
Occasionally, the `ssa_path` found by the algorithms can yield to huge value of `flops` and `size`. These ones can be larger than `typemax(Int128)`, which leads to negative values of both `flops` and `size`. Therefore, we need `BigInt` to ensure that this problem never happens.

### Example
With this PR, we can obtain `flops` and `size` values that are larger than `typemax(Int128)`:
```julia
julia> using OptimizedEinsum
julia> output, inputs, size_dict = rand_equation(100, 7)
(Symbol[], [[:á, :ń, :Ƙ, :Đ, :ī, :Ǎ, :Ł], [:ì, :Ǟ, :t, :ƈ, :P], [:Ŭ, :p, :Ż, :ƥ], [:Ö, :ę, :Ǫ, :ǅ, :Œ, :ǒ], [:w, :Ę, :ũ, :Ř, :Ķ, :ƍ, :Ɯ], [:ū, :Ǣ, :ś, :u], [:ā, :M, :é, :ê, :ƥ, :ŷ, :Ǚ, :ƻ], [:À, :ǌ, :ū, :ƅ, :È, :ƀ], [:ǧ, :Ʀ, :÷, :Ś, :ơ, :k, :Ƃ, :r], [:C, :l, :Ɣ, :Ě]  …  [:Ţ, :Ɵ, :f, :Ƴ, :Ɯ, :ð, :í], [:Ɵ, :ċ, :Ŷ, :Ð, :ŗ, :ƴ, :Ė], [:Ǐ, :Ž, :ƨ], [:Ý, :ǔ, :Ɖ, :å, :N, :ã, :×, :Ņ], [:ǧ, :Ŵ, :Þ, :Ǉ, :Ů, :ė, :Ê], [:D, :à, :ǂ, :ƿ, :Ƶ, :ô], [:ļ, :Ǖ, :ƒ, :ÿ, :Ǐ, :N, :ò, :O, :i], [:Ĺ, :ş, :ƪ, :ƣ, :Ű, :ŝ, :ƾ, :ñ], [:Ŗ, :Ň, :į, :Ɓ, :ţ, :ų, :Ì, :E], [:Ī, :s, :ň, :U, :Ó, :Ƹ, :Ƽ, :Ʈ]], Dict(:Á => 6, :Ű => 7, :Ɔ => 9, :ŉ => 3, :ǚ => 4, :Š => 6, :ƃ => 5, :Ǟ => 3, :Ė => 3, :ĝ => 4…))
julia> path_greedy = contractpath(Greedy, inputs, output, size_dict)
ContractionPath([(93, 97), (10, 40), (13, 25), (6, 46), (98, 14), (28, 23), (68, 85), (87, 51), (84, 88), (92, 43)  …  (189, 63), (190, 54), (191, 18), (192, 55), (193, 52), (194, 66), (195, 62), (196, 117), (197, 116), (49, 198)], [[:á, :ń, :Ƙ, :Đ, :ī, :Ǎ, :Ł], [:ì, :Ǟ, :t, :ƈ, :P], [:Ŭ, :p, :Ż, :ƥ], [:Ö, :ę, :Ǫ, :ǅ, :Œ, :ǒ], [:w, :Ę, :ũ, :Ř, :Ķ, :ƍ, :Ɯ], [:ū, :Ǣ, :ś, :u], [:ā, :M, :é, :ê, :ƥ, :ŷ, :Ǚ, :ƻ], [:À, :ǌ, :ū, :ƅ, :È, :ƀ], [:ǧ, :Ʀ, :÷, :Ś, :ơ, :k, :Ƃ, :r], [:C, :l, :Ɣ, :Ě]  …  [:Ţ, :Ɵ, :f, :Ƴ, :Ɯ, :ð, :í], [:Ɵ, :ċ, :Ŷ, :Ð, :ŗ, :ƴ, :Ė], [:Ǐ, :Ž, :ƨ], [:Ý, :ǔ, :Ɖ, :å, :N, :ã, :×, :Ņ], [:ǧ, :Ŵ, :Þ, :Ǉ, :Ů, :ė, :Ê], [:D, :à, :ǂ, :ƿ, :Ƶ, :ô], [:ļ, :Ǖ, :ƒ, :ÿ, :Ǐ, :N, :ò, :O, :i], [:Ĺ, :ş, :ƪ, :ƣ, :Ű, :ŝ, :ƾ, :ñ], [:Ŗ, :Ň, :į, :Ɓ, :ţ, :ų, :Ì, :E], [:Ī, :s, :ň, :U, :Ó, :Ƹ, :Ƽ, :Ʈ]], Symbol[], Dict(:Á => 6, :Ű => 7, :Ɔ => 9, :ŉ => 3, :ǚ => 4, :Š => 6, :ƃ => 5, :Ǟ => 3, :Ė => 3, :ĝ => 4…))
julia> flops, size = OptimizedEinsum.ssa_path_cost(path_greedy, inputs, output, size_dict)
(571334251666000069178068067701734681883374548960967007937069928002689169212532600190481500395330326798456546593871002, 9080118865895096320)
julia> flops > typemax(Int128)
true
```