### PR TITLE
Change type of `size` output of `Int` to `BigInt`

### DIFF
--- a/src/ContractionPath.jl
+++ b/src/ContractionPath.jl
@@ -43,7 +43,7 @@ function inds(path::ContractionPath, i)
     return symdiff(a, b) ∪ ∩(path.output, a, b)
 end
 
-Base.size(path::ContractionPath, i) = prod(ind -> path.size[ind], inds(path, i), init=1)
+Base.size(path::ContractionPath, i) = prod(ind -> path.size[ind], inds(path, i), init=one(BigInt))
 
 IteratorSize(::ContractionPath) = Base.HasLength()
 


### PR DESCRIPTION
### Summary
Change the output of the `size` function to be `BigInt`, since we can get sizes much larger than `typemax(Int64)` and this would lead to errors.

### Example
Without `BigInt`, the visualization of a large path breaks, even though the results from `ssa_path_cost` are okay.

```julia
julia> using OptimizedEinsum; using Makie; using CairoMakie
[ Info: Precompiling OptimizedEinsum [c9cfed12-e746-47c4-860d-affc68c43467]
julia> output = Symbol[]
Symbol[]
julia> inputs = [[:ą, :p, :ċ, :é, :ñ, :ž, :ƶ], [:Ǟ, :ś, :Ɖ, :x, :Ş, :Ě, :õ, :ǩ, :j], [:ǟ, :Ņ, :H], [:ų, :ě, :S, :ƒ, :ǁ, :Ƅ, :Ŀ], [:ĸ, :ŀ, :Š, :Č, :ħ, :V, :ť, :ń], [:Þ, :Ū, :ą, :Ƨ, :i, :B], [:ũ, :U, :ĝ, :R, :ǖ, :í], [:ċ, :Ǩ, :Ĵ, :ƪ, :Ɛ, :ƍ, :n, :Ŗ], [:c, :W, :Á, :ƙ, :ƭ, :Ǒ], [:ǔ, :ư, :d, :C, :o, :ǋ, :ł], [:Ç, :t, :Đ, :Ə, :ī, :Ǝ, :Ő, :ǌ], [:Ǔ, :ƃ, :J, :r, :ƅ, :ú, :ž, :û, :Ē], [:U, :Û, :Ń, :ţ, :Y, :ƣ, :à, :Ĩ, :Ţ], [:ǣ, :Ć, :ś, :ƚ], [:Ǚ, :ĩ, :ǀ], [:Ǜ, :ă, :ņ, :ë, :è], [:ð, :â, :ǒ, :ħ, :ď], [:ƅ, :ǖ, :Ƥ, :ĕ, :k, :ƒ], [:Ö, :Ð, :À, :ǟ, :ƨ, :Ł, :Ƨ, :ƿ], [:Ĥ, :S, :ģ, :ƿ, :Ę], [:Ƭ, :t, :L, :Ú, :ã, :Ķ, :Ɓ, :đ, :ǥ, :ǝ, :d, :f, :ŵ], [:Ŀ, :ſ, :ƈ, :Ą, :ř, :Ľ], [:ē, :I, :z, :ó, :ǂ, :İ], [:Ĳ, :Ƶ, :Ǥ], [:x, :Ǉ, :æ, :ƭ, :Q, :Ő, :Ƽ, :ŀ, :ó, :e, :ƕ], [:Ƭ, :ǐ, :Ŧ, :ƫ, :ǣ, :ƀ, :ǩ, :E], [:Ŕ, :Ø, :Ư, :Ʈ, :ƹ, :Ǔ, :Ō, :Ɯ, :ă], [:ű, :ė, :Ǡ, :o, :ƥ, :ƞ, :æ], [:Ğ, :Â, :Ʈ, :Ĺ, :Ž], [:Ñ, :Ť, :é, :Ð, :P], [:V, :ŗ, :ǌ, :ż, :Ė, :Ġ, :ø, :y], [:ŏ, :Ż, :ǚ, :ŧ, :Ƽ, :ê, :Ă, :ū], [:Ë, :ġ, :ğ, :Ɩ, :s, :v, :Ǆ], [:Ʋ, :Ɵ, :q, :ǡ, :ţ, :Ɖ, :ĥ, :A, :ù, :â], [:ǁ, :Ɔ, :Ʋ, :ŗ, :ķ], [:Į, :ğ, :ǃ, :Ñ, :Ŝ, :ò, :ń, :î], [:ć, :ǎ, :Ê], [:Ž, :÷, :Ƌ, :ŕ, :Ɣ, :ĺ, :b, :f], [:n, :È, :Ř, :ş, :ƨ, :Ǧ, :ô, :ĵ], [:Ŏ, :å, :Õ, :Ć, :ǘ, :M, :Ĭ, :Ǣ], [:y, :ď, :ü, :Ń, :ǅ, :Æ], [:Å, :Ħ, :ł, :ŕ, :ő, :ġ], [:Ę, :Ã, :ǀ, :ű, :ƈ, :Ô, :ƻ, :Ū], [:×, :G, :Ǖ, :ŭ, :Ǧ, :Ů], [:Ĺ, :u, :ĕ, :ƥ, :Ā, :Ċ], [:u, :w, :ā, :Ġ, :Ɠ, :ı, :à], [:Ģ, :ë, :Ŕ, :Ś, :Ɯ, :Œ, :Ô, :a], [:ŏ, :ǆ, :í, :Ţ, :ƕ, :Č, :ģ, :l, :Ļ], [:Ʀ, :C, :ļ, :ĸ, :ƺ, :ĝ], [:Ě, :ƛ, :Â, :r, :M, :Ɨ, :Ũ, :ƣ], [:Ŏ, :Ĝ, :ŉ, :ƻ, :Ƃ, :Þ], [:ę, :ÿ, :Ɠ, :þ, :ö], [:ǆ, :ß, :X, :ì, :ĭ, :z, :č], [:Ğ, :ŭ, :h, :Ó, :Ŭ, :į, :Ĉ, :Ù], [:Ʊ, :ƽ, :Ɗ, :ï, :ķ], [:ĭ, :÷, :Ö, :č, :ŷ, :ê, :ĩ], [:Ý, :Ǐ, :Q, :Ă, :Ó, :ǘ, :Ƙ], [:ľ, :×, :Ň, :Ŵ, :ż], [:Ī, :N, :Ù, :Ň, :ò, :Ů, :G, :ĳ], [:ī, :ü, :B, :Ǐ, :ı, :ū, :Ƈ, :š, :Ĉ], [:Ď, :e, :Ò, :ö, :Ɩ, :l, :þ, :D, :Ʀ, :Į, :Ä, :Ǖ, :X], [:ý, :Ƒ, :Ŗ, :Ŷ, :Ƶ, :ā], [:Ɲ, :ä, :ş, :Ų, :Ǎ, :Ƈ], [:w, :ň, :ǚ, :Ơ, :ř, :Ï, :Ź], [:ƞ, :g, :ļ, :Ǌ, :ŋ, :Ï, :œ], [:Ɣ, :ť, :Ō, :Ĝ, :Ǒ, :Œ, :ň, :j], [:Ĕ, :Ķ, :g, :ě, :Ƃ, :Ŭ, :ƍ, :õ, :m], [:ç, :Ė, :Ǆ, :ĥ, :ƌ, :š, :v, :Ë, :ǋ], [:Ƣ, :å, :ź, :Ű, :À, :Ş, :Ĳ, :H, :Á, :Ĭ], [:Í, :Ÿ, :ĺ, :ē, :Ƣ], [:Ǫ, :î, :F, :ù, :Å, :ŧ], [:ĵ, :œ, :ƪ, :ć, :Ģ, :Ǝ, :Ǩ], [:ƴ, :Ê, :Ǣ, :ő, :F, :ÿ, :Ɔ, :Ü, :Ǡ, :Ʃ], [:ơ, :c, :Ã, :ņ, :É, :Í, :Ĵ], [:ƫ, :ơ, :Ŋ, :ǒ, :ǡ, :Î, :Ǉ, :Đ], [:ė, :Ź, :Ƙ, :Ɵ, :ƀ], [:k, :ľ, :Æ, :Ǫ, :Ś], [:ƺ, :ō, :Ý, :Ʒ, :K, :Ā, :Ú, :Ť], [:Ʃ, :L, :ƚ, :T], [:ę, :Ì, :ƾ, :ǜ], [:T, :Ɓ, :Ƴ, :Ü, :Ə, :h, :Ʊ], [:ǧ, :ǔ, :Ƒ, :Ǌ, :ĳ], [:ũ, :ß, :ǝ, :O], [:ǥ, :ä, :D, :Ŵ, :Ř, :ƾ], [:Ą, :R, :ŝ, :Ǎ, :ø, :ǧ], [:Ħ, :Ǟ, :A, :ĉ, :Ĩ, :ƽ, :ư, :Ɗ, :Ɨ], [:Ŋ, :ƴ, :Ƥ, :Ÿ, :ǜ, :ō], [:I, :K, :Ĥ, :Î, :ð, :s, :ô], [:ǈ, :P, :ñ, :Ɛ, :ŵ, :Ø, :a], [:J, :è, :Ƴ, :ƛ, :Ű, :Ǚ, :b, :ź, :đ, :Ä, :Ǘ], [:Õ, :û, :Ŧ, :Ŝ, :ǈ, :ï], [:Ď, :ſ, :Ɲ], [:Ŷ, :ŷ, :E, :İ, :Ƹ, :É, :ƙ, :Ļ, :Ē, :ǉ, :ƃ], [:Û, :ǐ, :ǎ, :Ľ, :ŉ, :W, :Ư], [:ì, :ú, :i, :Ơ, :q, :ǃ, :Ĕ, :Ƹ], [:ŝ, :Ż, :ĉ, :á, :m, :Š, :ƶ], [:ǉ, :N, :ã, :ç, :ǅ], [:Ƅ, :O, :Ʒ, :Ì, :Ƌ, :ý], [:Ç, :È, :Ł, :Ǜ, :Ǘ, :Ī, :Ų, :Ǥ, :ǂ, :Y, :ų, :ů], [:Ņ, :á, :ƹ, :Ũ, :p, :į, :ŋ, :ƌ, :ů, :Ċ, :Ò]]
100-element Vector{Vector{Symbol}}:
 s[:ą, :p, :ċ, :é, :ñ, :ž, :ƶ]
 [:Ǟ, :ś, :Ɖ, :x, :Ş, :Ě, :õ, :ǩ, :j]
 [:ǟ, :Ņ, :H]
 [:ų, :ě, :S, :ƒ, :ǁ, :Ƅ, :Ŀ]
 [:ĸ, :ŀ, :Š, :Č, :ħ, :V, :ť, :ń]
 [:Þ, :Ū, :ą, :Ƨ, :i, :B]
 [:ũ, :U, :ĝ, :R, :ǖ, :í]
 [:ċ, :Ǩ, :Ĵ, :ƪ, :Ɛ, :ƍ, :n, :Ŗ]
 [:c, :W, :Á, :ƙ, :ƭ, :Ǒ]
 ⋮
 [:Ď, :ſ, :Ɲ]
 [:Ŷ, :ŷ, :E, :İ, :Ƹ, :É, :ƙ, :Ļ, :Ē, :ǉ, :ƃ]
 [:Û, :ǐ, :ǎ, :Ľ, :ŉ, :W, :Ư]
 [:ì, :ú, :i, :Ơ, :q, :ǃ, :Ĕ, :Ƹ]
 [:ŝ, :Ż, :ĉ, :á, :m, :Š, :ƶ]
 [:ǉ, :N, :ã, :ç, :ǅ]
 [:Ƅ, :O, :Ʒ, :Ì, :Ƌ, :ý]
 [:Ç, :È, :Ł, :Ǜ, :Ǘ, :Ī, :Ų, :Ǥ, :ǂ, :Y, :ų, :ů]
 [:Ņ, :á, :ƹ, :Ũ, :p, :į, :ŋ, :ƌ, :ů, :Ċ, :Ò]
julia> size_dict = Dict(:Á => 7, :Ű => 3, :Ɔ => 7, :ŉ => 9, :ǚ => 3, :Š => 6, :ƃ => 9, :Ǟ => 7, :Ė => 4, :ĝ => 3, :Ľ => 7, :Ŷ => 7, :m => 5, :ű => 4, :Ĉ => 5, :Ŏ => 5, :ś => 8, :Ƨ => 4, :æ => 6, :e => 9, :Ô => 8, :Ü => 3, :Ð => 4, :Ǔ => 7, :Ɣ => 8, :Ĺ => 8, :Ã => 3, :Ƈ => 9, :ō => 4, :þ => 3, :Ə => 3, :ƅ => 9, :ħ => 6, :Ħ => 7, :È => 6, :ŋ => 9, :Õ => 8, :ď => 6, :Ǝ => 5, :ŧ => 8, :ť => 2, :ĉ => 9, :ǉ => 4, :Ǐ => 7, :Ɵ => 3, :ï => 8, :Ɨ => 2, :X => 5, :Ò => 2, :ĺ => 4, :Ǎ => 4, :x => 2, :ñ => 9, :ŗ => 5, :ă => 3, :A => 2, :ų => 4, :Ư => 3, :í => 7, :Ǒ => 8, :ą => 9, :œ => 9, :à => 9, :Ŀ => 2, :b => 9, :ż => 3, :ň => 9, :n => 2, :Ÿ => 9, :l => 7, :w => 9, :ì => 3, :Ƭ => 8, :ã => 9, :ģ => 2, :Ɗ => 3, :ł => 2, :Ñ => 2, :ĥ => 5, :ƫ => 3, :ž => 8, :Ĕ => 4, :f => 7, :ě => 8, :P => 5, :H => 8, :Ń => 6, :Ć => 3, :ĸ => 2, :ǥ => 3, :õ => 2, :ó => 2, :ǅ => 9, :Ŭ => 6, :Ʃ => 7, :ī => 7, :ô => 2, :š => 7, :Ý => 8, :ƶ => 4, :d => 5, :ċ => 6, :Ņ => 5, :Ź => 5, :ƿ => 2, :Ě => 9, :y => 7, :ŝ => 6, :Ǉ => 9, :Œ => 3, :ƣ => 6, :Ē => 2, :ÿ => 3, :F => 6, :ŏ => 5, :ǟ => 8, :c => 2, :ū => 7, :Ä => 7, :ā => 3, :Ğ => 5, :Ƙ => 3, :Ǫ => 6, :Ċ => 7, :Æ => 3, :č => 3, :ŕ => 3, :M => 3, :Ă => 3, :s => 6, :Ɠ => 5, :Q => 3, :Ŧ => 8, :z => 6, :Ŗ => 6, :Å => 3, :Ĵ => 6, :Ƣ => 9, :ƥ => 6, :ğ => 9, :ƺ => 3, :ƛ => 8, :C => 6, :Ǖ => 3, :ı => 9, :j => 6, :û => 7, :Û => 8, :ơ => 6, :á => 6, :Ķ => 7, :ƒ => 7, :Ú => 2, :ƀ => 8, :Ŕ => 5, :ļ => 7, :ġ => 6, :Ɛ => 5, :Ő => 6, :Ʋ => 3, :r => 2, :Ų => 6, :ƍ => 3, :Ĩ => 7, :ư => 7, :Ƽ => 2, :ņ => 3, :ǋ => 7, :Ʊ => 4, :Ƥ => 3, :h => 5, :Ø => 7, :× => 8, :K => 7, :ĳ => 6, :Â => 6, :ö => 7, :Ģ => 9, :ø => 7, :Ç => 4, :â => 7, :Ĳ => 2, :ƹ => 8, :Ĝ => 6, :ǝ => 5, :Ł => 9, :ź => 3, :À => 8, :ǜ => 3, :ù => 8, :ǆ => 5, :ƽ => 3, :É => 3, :Ƹ => 3, :Ļ => 5, :÷ => 7, :ǡ => 3, :ǒ => 3, :S => 3, :Ǜ => 2, :ƻ => 5, :R => 3, :Ĥ => 6, :ǘ => 8, :k => 6, :ŵ => 5, :Ƃ => 3, :ƪ => 5, :Í => 5, :Þ => 9, :Ĭ => 5, :W => 5, :Ġ => 8, :Ž => 9, :O => 6, :ē => 8, :ǁ => 9, :Į => 8, :ƨ => 7, :N => 5, :ð => 6, :ê => 2, :Ŵ => 3, :ę => 4, :Y => 2, :ƾ => 2, :å => 7, :ǔ => 3, :Ū => 2, :ǧ => 8, :Ą => 3, :ŷ => 3, :ő => 7, :ƚ => 9, :Ň => 2, :Ǧ => 3, :Ơ => 8, :ǌ => 9, :ä => 2, :Ɩ => 2, :T => 3, :Ʒ => 8, :a => 5, :ǣ => 7, :Ù => 4, :Ā => 9, :ç => 8, :Ţ => 2, :ǈ => 3, :Ʈ => 7, :B => 4, :Ǘ => 5, :Ƅ => 2, :Ō => 6, :E => 9, :ƙ => 5, :q => 8, :ė => 3, :Ö => 8, :ǂ => 3, :Ď => 7, :Ɖ => 7, :t => 7, :ř => 2, :D => 7, :Ī => 9, :Ƴ => 9, :ĵ => 5, :Ƶ => 6, :ƭ => 5, :ũ => 3, :ú => 9, :Ů => 4, :Ǥ => 6, :Î => 5, :ý => 9, :ķ => 4, :Ť => 3, :ſ => 2, :o => 4, :p => 3, :ò => 5, :Ó => 4, :ƌ => 8, :Ś => 8, :é => 3, :ƕ => 5, :ń => 9, :Ê => 5, :Ǣ => 9, :ĩ => 8, :ë => 9, :Ƌ => 8, :è => 3, :v => 6, :İ => 9, :î => 9, :I => 5, :ü => 9, :G => 3, :Ǡ => 3, :ŭ => 8, :Ż => 2, :L => 5, :ŀ => 9, :ß => 6, :ǩ => 3, :ƴ => 2, :Ř => 2, :Ë => 9, :Ì => 9, :đ => 9, :ǖ => 9, :ľ => 7, :ǎ => 9, :ǀ => 7, :į => 9, :Ǆ => 2, :Ŝ => 8, :Ɓ => 7, :Ŋ => 4, :g => 9, :u => 5, :Ɲ => 2, :Ş => 8, :U => 5, :ş => 6, :J => 3, :Č => 9, :i => 6, :ĕ => 9, :ţ => 3, :ƞ => 6, :V => 5, :ĭ => 6, :Ɯ => 8, :ǃ => 6, :Đ => 9, :ǐ => 8, :ů => 2, :Ũ => 8, :Ƒ => 5, :ƈ => 9, :Ʀ => 4, :Ï => 6, :ć => 7, :Ǌ => 7, :Ǚ => 4, :Ę => 6, :Ǩ => 5)
Dict{Symbol, Int64} with 350 entries:
  :Á => 7
  :Ű => 3
  :Ɔ => 7
  :ŉ => 9
  :ǚ => 3
  :Š => 6
  :ƃ => 9
  :Ǟ => 7
  :Ė => 4
  :ĝ => 3
  :Ľ => 7
  :Ŷ => 7
  :m => 5
  :ű => 4
  :Ĉ => 5
  :Ŏ => 5
  :ś => 8
  :Ƨ => 4
  ⋮  => ⋮
julia> path_greedy = contractpath(Greedy, inputs, output, size_dict)
ContractionPath([(92, 61), (79, 14), (52, 80), (62, 24), (58, 84), (56, 15), (35, 55), (87, 70), (7, 83), (16, 74)  …  (189, 65), (190, 113), (191, 115), (192, 47), (193, 54), (194, 31), (116, 26), (196, 195), (197, 13), (67, 198)], [[:ą, :p, :ċ, :é, :ñ, :ž, :ƶ], [:Ǟ, :ś, :Ɖ, :x, :Ş, :Ě, :õ, :ǩ, :j], [:ǟ, :Ņ, :H], [:ų, :ě, :S, :ƒ, :ǁ, :Ƅ, :Ŀ], [:ĸ, :ŀ, :Š, :Č, :ħ, :V, :ť, :ń], [:Þ, :Ū, :ą, :Ƨ, :i, :B], [:ũ, :U, :ĝ, :R, :ǖ, :í], [:ċ, :Ǩ, :Ĵ, :ƪ, :Ɛ, :ƍ, :n, :Ŗ], [:c, :W, :Á, :ƙ, :ƭ, :Ǒ], [:ǔ, :ư, :d, :C, :o, :ǋ, :ł]  …  [:Õ, :û, :Ŧ, :Ŝ, :ǈ, :ï], [:Ď, :ſ, :Ɲ], [:Ŷ, :ŷ, :E, :İ, :Ƹ, :É, :ƙ, :Ļ, :Ē, :ǉ, :ƃ], [:Û, :ǐ, :ǎ, :Ľ, :ŉ, :W, :Ư], [:ì, :ú, :i, :Ơ, :q, :ǃ, :Ĕ, :Ƹ], [:ŝ, :Ż, :ĉ, :á, :m, :Š, :ƶ], [:ǉ, :N, :ã, :ç, :ǅ], [:Ƅ, :O, :Ʒ, :Ì, :Ƌ, :ý], [:Ç, :È, :Ł, :Ǜ, :Ǘ, :Ī, :Ų, :Ǥ, :ǂ, :Y, :ų, :ů], [:Ņ, :á, :ƹ, :Ũ, :p, :į, :ŋ, :ƌ, :ů, :Ċ, :Ò]], Symbol[], Dict(:Á => 7, :Ű => 3, :Ɔ => 7, :ŉ => 9, :ǚ => 3, :Š => 6, :ƃ => 9, :Ǟ => 7, :Ė => 4, :ĝ => 3…))
julia> (flops_greedy, size_greedy) = OptimizedEinsum.ssa_path_cost(path_greedy, inputs, output, size_dict)
(2766930271470903990669145277005780397450045380723852473639854050047405630992863915498875345102227724, 8201054921441673216)
julia> plot(path_greedy)
ERROR: DomainError with -8.847133971949552e18:
log10 will only return a complex result if called with a complex argument. Try log10(Complex(x)).
Stacktrace:
  [1] throw_complex_domainerror(f::Symbol, x::Float64)
    @ Base.Math ./math.jl:33
  [2] _log(x::Float64, base::Val{10}, func::Symbol)
    @ Base.Math ./special/log.jl:301
  [3] log10
    @ ./special/log.jl:268 [inlined]
  [4] log10
    @ ./math.jl:1372 [inlined]
  [5] #64
    @ ./none:0 [inlined]
  [6] iterate
    @ ./generator.jl:47 [inlined]
  [7] collect_to!(dest::Vector{Float64}, itr::Base.Generator{UnitRange{Int64}, OptimizedEinsum.var"#64#74"{ContractionPath}}, offs::Int64, st::Int64)
    @ Base ./array.jl:845
  [8] collect_to_with_first!
    @ ./array.jl:823 [inlined]
  [9] collect(itr::Base.Generator{UnitRange{Int64}, OptimizedEinsum.var"#64#74"{ContractionPath}})
    @ Base ./array.jl:797
 [10] #63
    @ ~/git/OptimizedEinsum.jl/src/Visualization.jl:15 [inlined]
 [11] get!(default::OptimizedEinsum.var"#63#73"{Graphs.SimpleGraphs.SimpleDiGraph{Int64}, ContractionPath}, h::Dict{Symbol, Any}, key::Symbol)
    @ Base ./dict.jl:481
 [12] plot!(P::Combined{GraphMakie.graphplot, Tuple{ContractionPath}}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ OptimizedEinsum ~/git/OptimizedEinsum.jl/src/Visualization.jl:14
 [13] plot!
    @ ~/git/OptimizedEinsum.jl/src/Visualization.jl:9 [inlined]
 [14] plot!(scene::Scene, P::Type{Combined{GraphMakie.graphplot, Tuple{ContractionPath}}}, attributes::Attributes, input::Tuple{Observable{ContractionPath}}, args::Observable{Tuple{ContractionPath}})
    @ Makie ~/.julia/packages/Makie/LCBYx/src/interfaces.jl:417
 [15] plot!(scene::Scene, P::Type{Any}, attributes::Attributes, args::ContractionPath; kw_attributes::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Makie ~/.julia/packages/Makie/LCBYx/src/interfaces.jl:335
 [16] plot!(scene::Scene, P::Type{Any}, attributes::Attributes, args::ContractionPath)
    @ Makie ~/.julia/packages/Makie/LCBYx/src/interfaces.jl:302
 [17] plot(P::Type{Any}, args::ContractionPath; axis::NamedTuple{(), Tuple{}}, figure::NamedTuple{(), Tuple{}}, kw_attributes::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Makie ~/.julia/packages/Makie/LCBYx/src/figureplotting.jl:48
 [18] plot
    @ ~/.julia/packages/Makie/LCBYx/src/figureplotting.jl:31 [inlined]
 [19] #plot#13
    @ ~/.julia/packages/MakieCore/77C6Z/src/recipes.jl:34 [inlined]
 [20] plot(args::ContractionPath)
    @ MakieCore ~/.julia/packages/MakieCore/77C6Z/src/recipes.jl:33
 [21] top-level scope
    @ REPL[6]:1
```