### PR TITLE
Fix `ssa_greedy_optimize` if output hyperindices

### DIFF
--- a/src/Solvers/Greedy.jl
+++ b/src/Solvers/Greedy.jl
@@ -78,6 +78,10 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     # if it appears in 3+, then it cannot be contracted (but indirect Hadamard products can)
     target_inds_histogram = histogram(Iterators.filter(∈(target_inds), Iterators.flatten(values(remaining))))
     high_ocurrent_inds = keys(filter(>(2) ∘ last, target_inds_histogram))
+
+    output_inds_histogram = histogram(Iterators.filter(∈(output), Iterators.flatten(values(remaining))))
+    any(x -> x > 2, values(output_inds_histogram)) && error("The 'Greedy' solver currently does not support output hyperindices.")
+
     # generate candidate pairwise contractions
     queue = BinaryMinHeap{HeapNode{Float64,NTuple{3,Set{Symbol}}}}()
 
@@ -98,6 +102,7 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
     while !isempty(queue)
         # select candidate
         winner = choose_fn(queue, remaining)
+
         if winner === nothing
             continue
         end
@@ -109,11 +114,11 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
         push!(ssa_path, (ssa_id_i, ssa_id_j))
 
         # update ocurrence histogram
-        for ind ∈ [a..., b...]
+        for ind ∈ filter(x -> x ∈ keys(target_inds_histogram), [a...,b...])
             target_inds_histogram[ind] -= 1
         end
 
-        for ind ∈ c
+        for ind ∈ filter(x -> x ∈ keys(target_inds_histogram), c)
             target_inds_histogram[ind] += 1
         end
 

--- a/src/Solvers/Greedy.jl
+++ b/src/Solvers/Greedy.jl
@@ -114,11 +114,11 @@ function ssa_greedy_optimize(inputs, output, size, choose_fn=greedy_choose_simpl
         push!(ssa_path, (ssa_id_i, ssa_id_j))
 
         # update ocurrence histogram
-        for ind ∈ filter(x -> x ∈ keys(target_inds_histogram), [a...,b...])
+        for ind ∈ Iterators.filter(x -> x ∈ keys(target_inds_histogram), [a...,b...])
             target_inds_histogram[ind] -= 1
         end
 
-        for ind ∈ filter(x -> x ∈ keys(target_inds_histogram), c)
+        for ind ∈ Iterators.filter(x -> x ∈ keys(target_inds_histogram), c)
             target_inds_histogram[ind] += 1
         end
 

--- a/test/ContractionPath_test.jl
+++ b/test/ContractionPath_test.jl
@@ -1,7 +1,7 @@
 @testset "ContractionPath" begin
     using OptimizedEinsum: ContractionPath, signatures, labels, rank
 
-    output = Symbol[] # TODO fix #23 and try `[:e]`
+    output = Symbol[:e]
     inputs = [[:h, :c, :f], [:a], [:d, :b], [:g, :d, :b, :a, :f], [:e, :h, :c, :g]]
     size_dict = Dict(:a => 5, :b => 5, :f => 8, :d => 2, :e => 2, :c => 4, :h => 9, :g => 8)
     ssapath = [(4, 3), (5, 1), (7, 6), (8, 2)]


### PR DESCRIPTION
Fix #23.

### Summary
Now it is possible to find the path for non-empty `output` using the `Greedy` and `RandomGreedy` solvers. We also added an exception that raises an error whenever a path does contain hyperindices at the `ouput`. 

### Example
Now the test in [test/ContractionPath_test.jl](https://github.com/bsc-quantic/OptimizedEinsum.jl/blob/master/test/ContractionPath_test.jl) works properly:
```julia
Test Summary:   | Pass  Total  Time
ContractionPath |   10     10  0.9s
Test.DefaultTestSet("ContractionPath", Any[], 10, false, false, true, 1.675080747261861e9, 1.675080748144805e9)
```