### PR TITLE
Add `labels` as a keyword argument into plot functions

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -9,17 +9,17 @@ const MAX_EDGE_WIDTH = 10.
 const MAX_ARROW_SIZE = 25.
 const MAX_NODE_SIZE = 40.
 
-function Makie.plot(path::ContractionPath; colormap = to_colormap(:viridis)[begin:end-10], interaction = true, kwargs...)
+function Makie.plot(path::ContractionPath; colormap = to_colormap(:viridis)[begin:end-10], labels = false, kwargs...)
     f = Figure()
 
-    p, ax = plot!(f[1,1], path; colormap, interaction, kwargs...)
+    p, ax = plot!(f[1,1], path; colormap, labels, kwargs...)
     display(f)
 
     return f, ax, p
 end
 
 # TODO replace `to_colormap(:viridis)[begin:end-10]` with a custom colormap
-function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_colormap(:viridis)[begin:end-10], interaction = true, kwargs...)
+function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_colormap(:viridis)[begin:end-10], labels = false, kwargs...)
     scene = Scene()
     default_attrs = default_theme(scene, GraphPlot)
 
@@ -39,10 +39,10 @@ function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_color
     kwargs[:node_size] = (log_flop/max_flop) * MAX_NODE_SIZE
     kwargs[:node_color] = log_flop
 
-    elabels = [join(labels(path, i)) for i in 1:ne(graph)]
+    elabels = [join(OptimizedEinsum.labels(path, i)) for i in 1:ne(graph)]
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa GraphMakie.NetworkLayout.IterativeLayout{3}
-        ax = interaction ? Axis3(f[1,1]) : LScene(f[1,1])
+        ax = LScene(f[1,1])
     else
         ax = Axis(f[1,1])
         # hide decorations if it is not a 3D plot
@@ -55,16 +55,15 @@ function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_color
     nlabels_fontsize = 40
 
     p = graphplot!(f[1,1], graph;
-        # nlabels=elabels;
-        # elabels_fontsize=12,
         arrow_attr = (colorrange=(min_size, max_size), colormap=colormap),
         edge_attr = (colorrange=(min_size, max_size), colormap=colormap),
         node_attr = (colorrange=(min_flop, max_flop),
         # TODO replace `to_colormap(:plasma)[begin:end-50]), kwargs...)` with a custom colormap
         colormap = to_colormap(:plasma)[begin:end-50]),
-        elabels,
-        elabels_color = :black,
-        elabels_textsize = [0 for i in 1:ne(graph)],
+        elabels = labels ? elabels : nothing,
+        elabels_color = [:black for i in 1:ne(graph)],
+        # TODO configurable `elabels_textsize`
+        elabels_textsize = [(log_size[i]/max_size) * 5 + 12 for i in 1:ne(graph)],
         kwargs...)
 
     # TODO configurable `labelsize`
@@ -77,16 +76,6 @@ function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_color
     # TODO configurable alignments
     cbar2.alignmode = Mixed(left = -10, right = -30)
     cbar.alignmode = Mixed(left = -30, right = -10)
-
-    if interaction
-        function edge_hover_action(state, idx, event, axis)
-            p.elabels_textsize[][idx] = state ? 18 : 0
-            p.elabels_textsize[] = p.elabels_textsize[]
-
-        end
-        ehover = EdgeHoverHandler(edge_hover_action)
-        register_interaction!(ax, :ehover, ehover)
-    end
 
     return p, ax
 end

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -51,9 +51,6 @@ function Makie.plot!(f::GridPosition, path::ContractionPath; colormap = to_color
         ax.aspect = DataAspect()
     end
 
-    # TODO configurable `nlables_fontsize`
-    nlabels_fontsize = 40
-
     p = graphplot!(f[1,1], graph;
         arrow_attr = (colorrange=(min_size, max_size), colormap=colormap),
         edge_attr = (colorrange=(min_size, max_size), colormap=colormap),

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -9,10 +9,10 @@ const MAX_EDGE_WIDTH = 10.
 const MAX_ARROW_SIZE = 25.
 const MAX_NODE_SIZE = 40.
 
-function Makie.plot(path::ContractionPath; colormap = to_colormap(:viridis)[begin:end-10], labels = false, kwargs...)
+function Makie.plot(path::ContractionPath; kwargs...)
     f = Figure()
 
-    p, ax = plot!(f[1,1], path; colormap, labels, kwargs...)
+    p, ax = plot!(f[1,1], path; kwargs...)
     display(f)
 
     return f, ax, p


### PR DESCRIPTION
From #10. 

### Summary
We add `labels` as a keyword argument into both `plot()` and `plot!()` functions. This argument is `false` by default, but if it's `true`, the plot shows the contraction label of each edge (tensor).

### Example
```julia
julia> using OptimizedEinsum
julia> using Makie
julia> using GLMakie
julia> output, inputs, size_dict = rand_equation(20, 2)
(Symbol[], [[:l, :d, :e, :f], [:k], [:h], [:k], [:q, :d, :s], [:b], [:i, :n, :m, :o], [:t], [:f, :b], [:o, :j], [:l, :c], [:g, :m], [:n, :e, :h], [:r, :c, :a], [:q, :a], [:p, :s], [:t, :r], [:i], [:g, :j], [:p]], Dict(:o => 6, :b => 3, :p => 9, :d => 2, :s => 7, :e => 2, :n => 6, :j => 5, :c => 7, :k => 7…))
julia> path = contractpath(RandomGreedy, inputs, output, size_dict)
ContractionPath([(2, 4), (7, 18), (16, 20), (22, 13), (19, 10), (23, 5), (25, 24), (27, 12), (28, 3), (6, 9), (30, 1), (31, 11), (8, 17), (33, 14), (26, 15), (35, 34), (36, 32), (29, 37), (21, 38)], [[:l, :d, :e, :f], [:k], [:h], [:k], [:q, :d, :s], [:b], [:i, :n, :m, :o], [:t], [:f, :b], [:o, :j], [:l, :c], [:g, :m], [:n, :e, :h], [:r, :c, :a], [:q, :a], [:p, :s], [:t, :r], [:i], [:g, :j], [:p]], Symbol[], Dict(:o => 6, :b => 3, :p => 9, :d => 2, :s => 7, :e => 2, :n => 6, :j => 5, :c => 7, :k => 7…))
julia> using NetworkLayout
julia> plot(path; labels=true, layout=Spring(dim=3))
(Scene (800px, 600px):
  0 Plots
  3 Child Scenes:
    ├ Scene (800px, 600px)
    ├ Scene (800px, 600px)
    └ Scene (800px, 600px), LScene(), Combined{GraphMakie.graphplot, Tuple{Graphs.SimpleGraphs.SimpleDiGraph{Int64}}})
```
![Screenshot from 2023-02-20 15-07-09](https://user-images.githubusercontent.com/61060572/220130234-8ce00154-f2db-43ff-83a8-eac54f6c1b17.png)
